### PR TITLE
chore: repo automation (labeler, CODEOWNERS, profiles, CI)

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,13 @@
+backend:
+  - backend/**
+frontend:
+  - frontend/**
+refactor:
+  - backend/src/main/java/com/company/evaluation/**/service/**
+  - backend/src/main/java/com/company/evaluation/**/controller/**
+  - frontend/src/**
+ci:
+  - .github/workflows/**
+config:
+  - backend/src/main/resources/**
+  - frontend/**/vite.config.*

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,17 @@
+name: PR Labeler
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler.yml
+
+


### PR DESCRIPTION
- PR 라벨러 워크플로/규칙 추가\n- CODEOWNERS 추가 (@Yijungu)\n- Spring profiles(dev/prod) 도입 및 기본 dev 활성화\n- CI 백엔드/프론트 잡\n\n머지 조건: CI(backend, frontend) 통과 + 1인 승인