### PR TITLE
ci(labeler): fix labeler v5 config on main

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,13 +1,24 @@
-backend:
-  - backend/**
-frontend:
-  - frontend/**
-refactor:
-  - backend/src/main/java/com/company/evaluation/**/service/**
-  - backend/src/main/java/com/company/evaluation/**/controller/**
-  - frontend/src/**
-ci:
-  - .github/workflows/**
-config:
-  - backend/src/main/resources/**
-  - frontend/**/vite.config.*
+labels:
+  - label: backend
+    changed-files:
+      - any-glob-to-any-file:
+          - "backend/**"
+  - label: frontend
+    changed-files:
+      - any-glob-to-any-file:
+          - "frontend/**"
+  - label: refactor
+    changed-files:
+      - any-glob-to-any-file:
+          - "backend/src/main/java/com/company/evaluation/**/service/**"
+          - "backend/src/main/java/com/company/evaluation/**/controller/**"
+          - "frontend/src/**"
+  - label: ci
+    changed-files:
+      - any-glob-to-any-file:
+          - ".github/workflows/**"
+  - label: config
+    changed-files:
+      - any-glob-to-any-file:
+          - "backend/src/main/resources/**"
+          - "frontend/**/vite.config.*"


### PR DESCRIPTION
actions/labeler@v5는 labels[] 스키마를 요구합니다.\n- .github/labeler.yml을 v5 구조로 수정\n- backend/frontend/refactor/ci/config 규칙 정의