### PR TITLE
refactor(frontend): modules-first 구조 도입 (#11)

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -12,7 +12,9 @@
         <RouterLink class="nav-link" to="/report">평가 보고서</RouterLink>
       </div>
     </nav>
-    <router-view />
+    <main class="container py-3">
+      <router-view />
+    </main>
   </div>
   
 </template>

--- a/frontend/src/modules/employees/pages/EmployeesPage.vue
+++ b/frontend/src/modules/employees/pages/EmployeesPage.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { ref, onMounted } from 'vue'
-import { searchEmployees, saveEmployee, uploadEmployeesExcel } from '../services/api'
+import { searchEmployees, saveEmployee, uploadEmployeesExcel } from '../../../services/api'
 
 const filters = ref({ name: '', status: '', region: '' })
 const employees = ref([])
@@ -185,5 +185,6 @@ onMounted(load)
 <style scoped>
 .container { max-width: 1100px; }
 </style>
+
 
 

--- a/frontend/src/modules/eval-items/pages/EvalItemsPage.vue
+++ b/frontend/src/modules/eval-items/pages/EvalItemsPage.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { ref, onMounted, computed } from 'vue'
-import api from '../services/api'
+import api from '../../../services/api'
 
 // 검색 영역
 const keyword = ref('')
@@ -152,5 +152,6 @@ onMounted(load)
     </div>
   </div>
 </template>
+
 
 

--- a/frontend/src/modules/evaluation/pages/EvaluationPage.vue
+++ b/frontend/src/modules/evaluation/pages/EvaluationPage.vue
@@ -1,6 +1,6 @@
 <script setup>
-import { ref, onMounted, computed } from 'vue'
-import { searchEmployees, getEvalItems, saveEvaluations, saveMemo, saveRaise, getEvaluations, getRaise } from '../services/api'
+import { ref, onMounted } from 'vue'
+import { searchEmployees, getEvalItems, saveEvaluations, saveMemo, saveRaise, getEvaluations, getRaise } from '../../../services/api'
 
 const employees = ref([])
 const items = ref([])
@@ -70,7 +70,6 @@ const load = async () => {
   ])
   employees.value = empRes.data.data.content ?? []
   items.value = itemRes.data.data ?? []
-  // init state rows with one empty row per employee
   // 직원별 기존 저장 점수 불러오기 + 기본 행 1개 보장
   for (const e of employees.value) {
     addRow(e.id)
@@ -169,5 +168,6 @@ onMounted(load)
     </div>
   </div>
 </template>
+
 
 

--- a/frontend/src/modules/report/pages/ReportPage.vue
+++ b/frontend/src/modules/report/pages/ReportPage.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { ref, onMounted, onBeforeUnmount, computed } from 'vue'
 import Chart from 'chart.js/auto'
-import api from '../services/api'
+import api from '../../../services/api'
 
 const data = ref(null)
 
@@ -93,7 +93,6 @@ const drawCharts = () => {
 const load = async () => {
   const res = await api.get('/report')
   data.value = res.data.data
-  // 다음 틱에 캔버스가 렌더링된 이후 차트 생성
   requestAnimationFrame(() => drawCharts())
 }
 
@@ -171,5 +170,6 @@ onBeforeUnmount(() => {
     </div>
   </div>
 </template>
+
 
 

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -1,9 +1,9 @@
 import { createRouter, createWebHistory } from 'vue-router'
 
-const Employees = () => import('../views/Employees.vue')
-const EvalItems = () => import('../views/EvalItems.vue')
-const Evaluation = () => import('../views/Evaluation.vue')
-const Report = () => import('../views/Report.vue')
+const Employees = () => import('../modules/employees/pages/EmployeesPage.vue')
+const EvalItems = () => import('../modules/eval-items/pages/EvalItemsPage.vue')
+const Evaluation = () => import('../modules/evaluation/pages/EvaluationPage.vue')
+const Report = () => import('../modules/report/pages/ReportPage.vue')
 
 const router = createRouter({
   history: createWebHistory(),


### PR DESCRIPTION
프론트 구조를 feature-first(modules-first)로 전환했습니다.\n\n주요 내용\n- /src/modules/*/pages 경로로 화면 분리 (Employees/EvalItems/Evaluation/Report)\n- router import 경로 수정\n- 기존 /views 제거\n\n빌드/런 방법\n- backend: mvn -DskipTests clean verify\n- frontend: npm ci && npm run dev (또는 build)\n\nCloses #11