### PR TITLE
refactor(frontend): 공통 API/서비스 레이어 정비 (#12)

### DIFF
--- a/frontend/src/modules/employees/pages/EmployeesPage.vue
+++ b/frontend/src/modules/employees/pages/EmployeesPage.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { ref, onMounted } from 'vue'
-import { searchEmployees, saveEmployee, uploadEmployeesExcel } from '../../../services/api'
+import { searchEmployees, saveEmployee, uploadEmployeesExcel } from '../services/employees.service'
 
 const filters = ref({ name: '', status: '', region: '' })
 const employees = ref([])

--- a/frontend/src/modules/employees/services/employees.service.js
+++ b/frontend/src/modules/employees/services/employees.service.js
@@ -1,0 +1,11 @@
+import api from '../../../services/api'
+
+export const searchEmployees = (params) => api.get('/employees', { params })
+export const saveEmployee = (payload) => api.post('/employees', payload)
+export const uploadEmployeesExcel = (file) => {
+  const form = new FormData()
+  form.append('file', file)
+  return api.post('/employees/upload', form, { headers: { 'Content-Type': 'multipart/form-data' } })
+}
+
+

--- a/frontend/src/modules/eval-items/pages/EvalItemsPage.vue
+++ b/frontend/src/modules/eval-items/pages/EvalItemsPage.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { ref, onMounted, computed } from 'vue'
-import api from '../../../services/api'
+import { getEvalCategories, getEvalItems, createEvalItem, updateEvalItem, createCategory } from '../services/eval-items.service'
 
 // 검색 영역
 const keyword = ref('')
@@ -24,8 +24,8 @@ const newCategoryName = ref('')
 
 const load = async () => {
   const [catRes, itemRes] = await Promise.all([
-    api.get('/categories'),
-    api.get('/items')
+    getEvalCategories(),
+    getEvalItems(),
   ])
   categories.value = catRes.data.data || []
   const list = itemRes.data.data || []
@@ -41,14 +41,14 @@ const saveItem = async () => {
     description: form.value.description,
     categoryId: form.value.categoryId ? Number(form.value.categoryId) : null,
   }
-  if (form.value.id) await api.put(`/items/${form.value.id}`, payload)
-  else await api.post('/items', payload)
+  if (form.value.id) await updateEvalItem(form.value.id, payload)
+  else await createEvalItem(payload)
   await load(); showForm.value = false; alert('저장 완료')
 }
 
 const addCategory = async () => {
   if (!newCategoryName.value) return
-  await api.post('/categories', { name: newCategoryName.value })
+  await createCategory(newCategoryName.value)
   newCategoryName.value = ''
   await load()
 }

--- a/frontend/src/modules/eval-items/services/eval-items.service.js
+++ b/frontend/src/modules/eval-items/services/eval-items.service.js
@@ -1,0 +1,9 @@
+import api from '../../../services/api'
+
+export const getEvalCategories = () => api.get('/categories')
+export const getEvalItems = () => api.get('/items')
+export const createEvalItem = (payload) => api.post('/items', payload)
+export const updateEvalItem = (id, payload) => api.put(`/items/${id}`, payload)
+export const createCategory = (name) => api.post('/categories', { name })
+
+

--- a/frontend/src/modules/evaluation/pages/EvaluationPage.vue
+++ b/frontend/src/modules/evaluation/pages/EvaluationPage.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { ref, onMounted } from 'vue'
-import { searchEmployees, getEvalItems, saveEvaluations, saveMemo, saveRaise, getEvaluations, getRaise } from '../../../services/api'
+import { searchEmployees } from '../../employees/services/employees.service'
+import { getEvalItems, saveEvaluations, saveMemo, saveRaise, getEvaluations, getRaise } from '../services/evaluation.service'
 
 const employees = ref([])
 const items = ref([])

--- a/frontend/src/modules/evaluation/services/evaluation.service.js
+++ b/frontend/src/modules/evaluation/services/evaluation.service.js
@@ -1,0 +1,10 @@
+import api from '../../../services/api'
+
+export const getEvalItems = () => api.get('/items')
+export const getEvaluations = (employeeId) => api.get(`/employees/${employeeId}/evaluations`)
+export const saveEvaluations = (employeeId, list) => api.post(`/employees/${employeeId}/evaluations`, list)
+export const getRaise = (employeeId) => api.get(`/employees/${employeeId}/raise`)
+export const saveRaise = (employeeId, raise) => api.post(`/employees/${employeeId}/raise`, raise)
+export const saveMemo = (employeeId, memo) => api.post(`/employees/${employeeId}/memos`, memo)
+
+

--- a/frontend/src/modules/report/pages/ReportPage.vue
+++ b/frontend/src/modules/report/pages/ReportPage.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { ref, onMounted, onBeforeUnmount, computed } from 'vue'
 import Chart from 'chart.js/auto'
-import api from '../../../services/api'
+import { getReport } from '../services/report.service'
 
 const data = ref(null)
 
@@ -91,7 +91,7 @@ const drawCharts = () => {
 }
 
 const load = async () => {
-  const res = await api.get('/report')
+  const res = await getReport()
   data.value = res.data.data
   requestAnimationFrame(() => drawCharts())
 }

--- a/frontend/src/modules/report/services/report.service.js
+++ b/frontend/src/modules/report/services/report.service.js
@@ -1,0 +1,5 @@
+import api from '../../../services/api'
+
+export const getReport = () => api.get('/report')
+
+

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -4,24 +4,20 @@ const api = axios.create({
   baseURL: '/api',
 })
 
+// 공통 인터셉터: 에러 로깅 및 사용자 메시지 처리 기반
+api.interceptors.response.use(
+  (res) => res,
+  (err) => {
+    // 간단한 에러 메시지 노출
+    const msg = err?.response?.data?.message || err.message || '요청 처리 중 오류가 발생했습니다.'
+    if (typeof window !== 'undefined') {
+      // eslint-disable-next-line no-alert
+      alert(msg)
+    }
+    return Promise.reject(err)
+  }
+)
+
 export default api
-
-// Employee APIs
-export const searchEmployees = (params) => api.get('/employees', { params })
-export const saveEmployee = (payload) => api.post('/employees', payload)
-export const uploadEmployeesExcel = (file) => {
-  const form = new FormData()
-  form.append('file', file)
-  return api.post('/employees/upload', form, { headers: { 'Content-Type': 'multipart/form-data' } })
-}
-
-// Eval APIs
-export const getEvalCategories = () => api.get('/categories')
-export const getEvalItems = () => api.get('/items')
-export const saveEvaluations = (employeeId, list) => api.post(`/employees/${employeeId}/evaluations`, list)
-export const saveMemo = (employeeId, memo) => api.post(`/employees/${employeeId}/memos`, memo)
-export const saveRaise = (employeeId, raise) => api.post(`/employees/${employeeId}/raise`, raise)
-export const getEvaluations = (employeeId) => api.get(`/employees/${employeeId}/evaluations`)
-export const getRaise = (employeeId) => api.get(`/employees/${employeeId}/raise`)
 
 


### PR DESCRIPTION
모듈 서비스 레이어 도입 및 axios 인터셉터 추가로 프론트 구조를 정비했습니다.\n\n- axios 인스턴스 인터셉터 추가(에러 핸들)\n- employees/eval-items/evaluation/report 모듈별 service 구성\n- 각 페이지에서 모듈 서비스 사용\n\nCloses #12