### PR TITLE
refactor(backend): eval 패키지 계층 분리(domain/repository)

### DIFF
--- a/backend/src/main/java/com/company/evaluation/eval/EvalController.java
+++ b/backend/src/main/java/com/company/evaluation/eval/EvalController.java
@@ -1,6 +1,9 @@
 package com.company.evaluation.eval;
 
 import com.company.evaluation.common.ApiResponse;
+import com.company.evaluation.eval.domain.EmployeeMemo;
+import com.company.evaluation.eval.domain.Evaluation;
+import com.company.evaluation.eval.domain.EvalCategory;
 import com.company.evaluation.eval.dto.EvalItemRequest;
 import com.company.evaluation.eval.dto.EvalItemResponse;
 import jakarta.validation.Valid;

--- a/backend/src/main/java/com/company/evaluation/eval/EvalItemDto.java
+++ b/backend/src/main/java/com/company/evaluation/eval/EvalItemDto.java
@@ -4,6 +4,7 @@ import jakarta.validation.constraints.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import com.company.evaluation.eval.domain.EvalItem;
 
 @Data
 @NoArgsConstructor

--- a/backend/src/main/java/com/company/evaluation/eval/EvalItemScoreDto.java
+++ b/backend/src/main/java/com/company/evaluation/eval/EvalItemScoreDto.java
@@ -3,6 +3,7 @@ package com.company.evaluation.eval;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import com.company.evaluation.eval.domain.Evaluation;
 
 @Data
 @NoArgsConstructor

--- a/backend/src/main/java/com/company/evaluation/eval/EvalService.java
+++ b/backend/src/main/java/com/company/evaluation/eval/EvalService.java
@@ -2,6 +2,8 @@ package com.company.evaluation.eval;
 
 import com.company.evaluation.employee.Employee;
 import com.company.evaluation.employee.EmployeeRepository;
+import com.company.evaluation.eval.domain.*;
+import com.company.evaluation.eval.repository.*;
 import com.company.evaluation.eval.dto.EvalItemRequest;
 import com.company.evaluation.eval.dto.EvalItemResponse;
 import com.company.evaluation.eval.dto.EvaluationRowResponse;

--- a/backend/src/main/java/com/company/evaluation/eval/SalaryRaiseDto.java
+++ b/backend/src/main/java/com/company/evaluation/eval/SalaryRaiseDto.java
@@ -3,6 +3,7 @@ package com.company.evaluation.eval;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import com.company.evaluation.eval.domain.SalaryRaise;
 
 @Data
 @NoArgsConstructor

--- a/backend/src/main/java/com/company/evaluation/eval/domain/EmployeeMemo.java
+++ b/backend/src/main/java/com/company/evaluation/eval/domain/EmployeeMemo.java
@@ -1,4 +1,4 @@
-package com.company.evaluation.eval;
+package com.company.evaluation.eval.domain;
 
 import com.company.evaluation.employee.Employee;
 import jakarta.persistence.*;

--- a/backend/src/main/java/com/company/evaluation/eval/domain/EvalCategory.java
+++ b/backend/src/main/java/com/company/evaluation/eval/domain/EvalCategory.java
@@ -1,4 +1,4 @@
-package com.company.evaluation.eval;
+package com.company.evaluation.eval.domain;
 
 import jakarta.persistence.*;
 import lombok.Getter;

--- a/backend/src/main/java/com/company/evaluation/eval/domain/EvalItem.java
+++ b/backend/src/main/java/com/company/evaluation/eval/domain/EvalItem.java
@@ -1,4 +1,4 @@
-package com.company.evaluation.eval;
+package com.company.evaluation.eval.domain;
 
 import jakarta.persistence.*;
 import lombok.Getter;

--- a/backend/src/main/java/com/company/evaluation/eval/domain/Evaluation.java
+++ b/backend/src/main/java/com/company/evaluation/eval/domain/Evaluation.java
@@ -1,4 +1,4 @@
-package com.company.evaluation.eval;
+package com.company.evaluation.eval.domain;
 
 import com.company.evaluation.employee.Employee;
 import jakarta.persistence.*;

--- a/backend/src/main/java/com/company/evaluation/eval/domain/SalaryRaise.java
+++ b/backend/src/main/java/com/company/evaluation/eval/domain/SalaryRaise.java
@@ -1,4 +1,4 @@
-package com.company.evaluation.eval;
+package com.company.evaluation.eval.domain;
 
 import com.company.evaluation.employee.Employee;
 import jakarta.persistence.*;

--- a/backend/src/main/java/com/company/evaluation/eval/mapper/EvalItemMapper.java
+++ b/backend/src/main/java/com/company/evaluation/eval/mapper/EvalItemMapper.java
@@ -1,7 +1,7 @@
 package com.company.evaluation.eval.mapper;
 
-import com.company.evaluation.eval.EvalItem;
-import com.company.evaluation.eval.EvalCategory;
+import com.company.evaluation.eval.domain.EvalItem;
+import com.company.evaluation.eval.domain.EvalCategory;
 import com.company.evaluation.eval.dto.EvalItemRequest;
 import com.company.evaluation.eval.dto.EvalItemResponse;
 import org.mapstruct.*;

--- a/backend/src/main/java/com/company/evaluation/eval/repository/EmployeeMemoRepository.java
+++ b/backend/src/main/java/com/company/evaluation/eval/repository/EmployeeMemoRepository.java
@@ -1,5 +1,6 @@
-package com.company.evaluation.eval;
+package com.company.evaluation.eval.repository;
 
+import com.company.evaluation.eval.domain.EmployeeMemo;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 

--- a/backend/src/main/java/com/company/evaluation/eval/repository/EvalCategoryRepository.java
+++ b/backend/src/main/java/com/company/evaluation/eval/repository/EvalCategoryRepository.java
@@ -1,5 +1,6 @@
-package com.company.evaluation.eval;
+package com.company.evaluation.eval.repository;
 
+import com.company.evaluation.eval.domain.EvalCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface EvalCategoryRepository extends JpaRepository<EvalCategory, Long> {}

--- a/backend/src/main/java/com/company/evaluation/eval/repository/EvalItemRepository.java
+++ b/backend/src/main/java/com/company/evaluation/eval/repository/EvalItemRepository.java
@@ -1,5 +1,6 @@
-package com.company.evaluation.eval;
+package com.company.evaluation.eval.repository;
 
+import com.company.evaluation.eval.domain.EvalItem;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface EvalItemRepository extends JpaRepository<EvalItem, Long> {}

--- a/backend/src/main/java/com/company/evaluation/eval/repository/EvaluationRepository.java
+++ b/backend/src/main/java/com/company/evaluation/eval/repository/EvaluationRepository.java
@@ -1,5 +1,6 @@
-package com.company.evaluation.eval;
+package com.company.evaluation.eval.repository;
 
+import com.company.evaluation.eval.domain.Evaluation;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;

--- a/backend/src/main/java/com/company/evaluation/eval/repository/SalaryRaiseRepository.java
+++ b/backend/src/main/java/com/company/evaluation/eval/repository/SalaryRaiseRepository.java
@@ -1,5 +1,6 @@
-package com.company.evaluation.eval;
+package com.company.evaluation.eval.repository;
 
+import com.company.evaluation.eval.domain.SalaryRaise;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 

--- a/backend/src/main/java/com/company/evaluation/report/ReportService.java
+++ b/backend/src/main/java/com/company/evaluation/report/ReportService.java
@@ -2,9 +2,9 @@ package com.company.evaluation.report;
 
 import com.company.evaluation.employee.Employee;
 import com.company.evaluation.employee.EmployeeRepository;
-import com.company.evaluation.eval.EvaluationRepository;
-import com.company.evaluation.eval.SalaryRaise;
-import com.company.evaluation.eval.SalaryRaiseRepository;
+import com.company.evaluation.eval.repository.EvaluationRepository;
+import com.company.evaluation.eval.domain.SalaryRaise;
+import com.company.evaluation.eval.repository.SalaryRaiseRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.*;


### PR DESCRIPTION
eval 패키지의 책임을 계층별로 분리했습니다.\n\n- domain/*: 엔티티 이동 (Evaluation, EvalItem, EvalCategory, EmployeeMemo, SalaryRaise)\n- repository/*: 레포 이동/정리\n- 서비스/컨트롤러/리포트 의존 경로 수정\n- 로컬 빌드 성공