### PR TITLE
refactor(frontend): 모듈 계층 보강 및 컴포넌트 분리

### DIFF
--- a/backend/src/main/java/com/company/evaluation/eval/EvalController.java
+++ b/backend/src/main/java/com/company/evaluation/eval/EvalController.java
@@ -1,6 +1,9 @@
 package com.company.evaluation.eval;
 
 import com.company.evaluation.common.ApiResponse;
+import com.company.evaluation.eval.domain.EmployeeMemo;
+import com.company.evaluation.eval.domain.Evaluation;
+import com.company.evaluation.eval.domain.EvalCategory;
 import com.company.evaluation.eval.dto.EvalItemRequest;
 import com.company.evaluation.eval.dto.EvalItemResponse;
 import jakarta.validation.Valid;

--- a/backend/src/main/java/com/company/evaluation/eval/EvalItemDto.java
+++ b/backend/src/main/java/com/company/evaluation/eval/EvalItemDto.java
@@ -4,6 +4,7 @@ import jakarta.validation.constraints.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import com.company.evaluation.eval.domain.EvalItem;
 
 @Data
 @NoArgsConstructor

--- a/backend/src/main/java/com/company/evaluation/eval/EvalItemScoreDto.java
+++ b/backend/src/main/java/com/company/evaluation/eval/EvalItemScoreDto.java
@@ -3,6 +3,7 @@ package com.company.evaluation.eval;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import com.company.evaluation.eval.domain.Evaluation;
 
 @Data
 @NoArgsConstructor

--- a/backend/src/main/java/com/company/evaluation/eval/EvalService.java
+++ b/backend/src/main/java/com/company/evaluation/eval/EvalService.java
@@ -2,6 +2,8 @@ package com.company.evaluation.eval;
 
 import com.company.evaluation.employee.Employee;
 import com.company.evaluation.employee.EmployeeRepository;
+import com.company.evaluation.eval.domain.*;
+import com.company.evaluation.eval.repository.*;
 import com.company.evaluation.eval.dto.EvalItemRequest;
 import com.company.evaluation.eval.dto.EvalItemResponse;
 import com.company.evaluation.eval.dto.EvaluationRowResponse;

--- a/backend/src/main/java/com/company/evaluation/eval/SalaryRaiseDto.java
+++ b/backend/src/main/java/com/company/evaluation/eval/SalaryRaiseDto.java
@@ -3,6 +3,7 @@ package com.company.evaluation.eval;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import com.company.evaluation.eval.domain.SalaryRaise;
 
 @Data
 @NoArgsConstructor

--- a/backend/src/main/java/com/company/evaluation/eval/domain/EmployeeMemo.java
+++ b/backend/src/main/java/com/company/evaluation/eval/domain/EmployeeMemo.java
@@ -1,4 +1,4 @@
-package com.company.evaluation.eval;
+package com.company.evaluation.eval.domain;
 
 import com.company.evaluation.employee.Employee;
 import jakarta.persistence.*;

--- a/backend/src/main/java/com/company/evaluation/eval/domain/EvalCategory.java
+++ b/backend/src/main/java/com/company/evaluation/eval/domain/EvalCategory.java
@@ -1,4 +1,4 @@
-package com.company.evaluation.eval;
+package com.company.evaluation.eval.domain;
 
 import jakarta.persistence.*;
 import lombok.Getter;

--- a/backend/src/main/java/com/company/evaluation/eval/domain/EvalItem.java
+++ b/backend/src/main/java/com/company/evaluation/eval/domain/EvalItem.java
@@ -1,4 +1,4 @@
-package com.company.evaluation.eval;
+package com.company.evaluation.eval.domain;
 
 import jakarta.persistence.*;
 import lombok.Getter;

--- a/backend/src/main/java/com/company/evaluation/eval/domain/Evaluation.java
+++ b/backend/src/main/java/com/company/evaluation/eval/domain/Evaluation.java
@@ -1,4 +1,4 @@
-package com.company.evaluation.eval;
+package com.company.evaluation.eval.domain;
 
 import com.company.evaluation.employee.Employee;
 import jakarta.persistence.*;

--- a/backend/src/main/java/com/company/evaluation/eval/domain/SalaryRaise.java
+++ b/backend/src/main/java/com/company/evaluation/eval/domain/SalaryRaise.java
@@ -1,4 +1,4 @@
-package com.company.evaluation.eval;
+package com.company.evaluation.eval.domain;
 
 import com.company.evaluation.employee.Employee;
 import jakarta.persistence.*;

--- a/backend/src/main/java/com/company/evaluation/eval/mapper/EvalItemMapper.java
+++ b/backend/src/main/java/com/company/evaluation/eval/mapper/EvalItemMapper.java
@@ -1,7 +1,7 @@
 package com.company.evaluation.eval.mapper;
 
-import com.company.evaluation.eval.EvalItem;
-import com.company.evaluation.eval.EvalCategory;
+import com.company.evaluation.eval.domain.EvalItem;
+import com.company.evaluation.eval.domain.EvalCategory;
 import com.company.evaluation.eval.dto.EvalItemRequest;
 import com.company.evaluation.eval.dto.EvalItemResponse;
 import org.mapstruct.*;

--- a/backend/src/main/java/com/company/evaluation/eval/repository/EmployeeMemoRepository.java
+++ b/backend/src/main/java/com/company/evaluation/eval/repository/EmployeeMemoRepository.java
@@ -1,5 +1,6 @@
-package com.company.evaluation.eval;
+package com.company.evaluation.eval.repository;
 
+import com.company.evaluation.eval.domain.EmployeeMemo;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 

--- a/backend/src/main/java/com/company/evaluation/eval/repository/EvalCategoryRepository.java
+++ b/backend/src/main/java/com/company/evaluation/eval/repository/EvalCategoryRepository.java
@@ -1,5 +1,6 @@
-package com.company.evaluation.eval;
+package com.company.evaluation.eval.repository;
 
+import com.company.evaluation.eval.domain.EvalCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface EvalCategoryRepository extends JpaRepository<EvalCategory, Long> {}

--- a/backend/src/main/java/com/company/evaluation/eval/repository/EvalItemRepository.java
+++ b/backend/src/main/java/com/company/evaluation/eval/repository/EvalItemRepository.java
@@ -1,5 +1,6 @@
-package com.company.evaluation.eval;
+package com.company.evaluation.eval.repository;
 
+import com.company.evaluation.eval.domain.EvalItem;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface EvalItemRepository extends JpaRepository<EvalItem, Long> {}

--- a/backend/src/main/java/com/company/evaluation/eval/repository/EvaluationRepository.java
+++ b/backend/src/main/java/com/company/evaluation/eval/repository/EvaluationRepository.java
@@ -1,5 +1,6 @@
-package com.company.evaluation.eval;
+package com.company.evaluation.eval.repository;
 
+import com.company.evaluation.eval.domain.Evaluation;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;

--- a/backend/src/main/java/com/company/evaluation/eval/repository/SalaryRaiseRepository.java
+++ b/backend/src/main/java/com/company/evaluation/eval/repository/SalaryRaiseRepository.java
@@ -1,5 +1,6 @@
-package com.company.evaluation.eval;
+package com.company.evaluation.eval.repository;
 
+import com.company.evaluation.eval.domain.SalaryRaise;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 

--- a/backend/src/main/java/com/company/evaluation/report/ReportService.java
+++ b/backend/src/main/java/com/company/evaluation/report/ReportService.java
@@ -2,9 +2,9 @@ package com.company.evaluation.report;
 
 import com.company.evaluation.employee.Employee;
 import com.company.evaluation.employee.EmployeeRepository;
-import com.company.evaluation.eval.EvaluationRepository;
-import com.company.evaluation.eval.SalaryRaise;
-import com.company.evaluation.eval.SalaryRaiseRepository;
+import com.company.evaluation.eval.repository.EvaluationRepository;
+import com.company.evaluation.eval.domain.SalaryRaise;
+import com.company.evaluation.eval.repository.SalaryRaiseRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.*;

--- a/frontend/src/modules/employees/components/EmployeeFormModal.vue
+++ b/frontend/src/modules/employees/components/EmployeeFormModal.vue
@@ -1,0 +1,83 @@
+<script setup>
+import { toRefs } from 'vue'
+
+const props = defineProps({
+  form: { type: Object, required: true },
+})
+const emit = defineEmits(['save'])
+const { form } = toRefs(props)
+
+const onSave = () => emit('save')
+</script>
+
+<template>
+  <div class="modal fade" id="empModal" tabindex="-1">
+    <div class="modal-dialog modal-lg">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">사원 등록/수정</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <div class="row g-2">
+            <div class="col-md-4">
+              <label class="form-label">사원명</label>
+              <input v-model="form.name" class="form-control" />
+            </div>
+            <div class="col-md-4">
+              <label class="form-label">사번</label>
+              <input v-model="form.employeeNumber" class="form-control" />
+            </div>
+            <div class="col-md-4">
+              <label class="form-label">급여</label>
+              <input v-model.number="form.baseSalary" type="number" class="form-control" />
+            </div>
+            <div class="col-md-4">
+              <label class="form-label">입사년도</label>
+              <input v-model.number="form.joinYear" type="number" class="form-control" />
+            </div>
+            <div class="col-md-4">
+              <label class="form-label">직급</label>
+              <input v-model="form.position" class="form-control" />
+            </div>
+            <div class="col-md-4">
+              <label class="form-label">근무 상태</label>
+              <select v-model="form.workStatus" class="form-select">
+                <option>근무</option>
+                <option>휴직</option>
+                <option>퇴직</option>
+              </select>
+            </div>
+            <div class="col-md-4">
+              <label class="form-label">근무 지역</label>
+              <select v-model="form.workRegion" class="form-select">
+                <option>국내</option>
+                <option>미국법인</option>
+                <option>유럽법인</option>
+              </select>
+            </div>
+            <div class="col-md-4">
+              <label class="form-label">이메일</label>
+              <input v-model="form.email" type="email" class="form-control" />
+            </div>
+            <div class="col-md-4">
+              <label class="form-label">전화번호</label>
+              <input v-model="form.phone" class="form-control" />
+            </div>
+            <div class="col-12">
+              <label class="form-label">메모</label>
+              <textarea v-model="form.notes" rows="2" class="form-control"></textarea>
+            </div>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button class="btn btn-secondary" data-bs-dismiss="modal">닫기</button>
+          <button class="btn btn-primary" @click="onSave">저장</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  
+</template>
+
+

--- a/frontend/src/modules/employees/pages/EmployeesPage.vue
+++ b/frontend/src/modules/employees/pages/EmployeesPage.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { ref, onMounted } from 'vue'
 import { searchEmployees, saveEmployee, uploadEmployeesExcel } from '../services/employees.service'
+import EmployeeFormModal from '../components/EmployeeFormModal.vue'
 
 const filters = ref({ name: '', status: '', region: '' })
 const employees = ref([])
@@ -112,73 +113,7 @@ onMounted(load)
       </table>
     </div>
 
-    <!-- Modal -->
-    <div class="modal fade" id="empModal" tabindex="-1">
-      <div class="modal-dialog modal-lg">
-        <div class="modal-content">
-          <div class="modal-header">
-            <h5 class="modal-title">사원 등록/수정</h5>
-            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-          </div>
-          <div class="modal-body">
-            <div class="row g-2">
-              <div class="col-md-4">
-                <label class="form-label">사원명</label>
-                <input v-model="form.name" class="form-control" />
-              </div>
-              <div class="col-md-4">
-                <label class="form-label">사번</label>
-                <input v-model="form.employeeNumber" class="form-control" />
-              </div>
-              <div class="col-md-4">
-                <label class="form-label">급여</label>
-                <input v-model.number="form.baseSalary" type="number" class="form-control" />
-              </div>
-              <div class="col-md-4">
-                <label class="form-label">입사년도</label>
-                <input v-model.number="form.joinYear" type="number" class="form-control" />
-              </div>
-              <div class="col-md-4">
-                <label class="form-label">직급</label>
-                <input v-model="form.position" class="form-control" />
-              </div>
-              <div class="col-md-4">
-                <label class="form-label">근무 상태</label>
-                <select v-model="form.workStatus" class="form-select">
-                  <option>근무</option>
-                  <option>휴직</option>
-                  <option>퇴직</option>
-                </select>
-              </div>
-              <div class="col-md-4">
-                <label class="form-label">근무 지역</label>
-                <select v-model="form.workRegion" class="form-select">
-                  <option>국내</option>
-                  <option>미국법인</option>
-                  <option>유럽법인</option>
-                </select>
-              </div>
-              <div class="col-md-4">
-                <label class="form-label">이메일</label>
-                <input v-model="form.email" type="email" class="form-control" />
-              </div>
-              <div class="col-md-4">
-                <label class="form-label">전화번호</label>
-                <input v-model="form.phone" class="form-control" />
-              </div>
-              <div class="col-12">
-                <label class="form-label">메모</label>
-                <textarea v-model="form.notes" rows="2" class="form-control"></textarea>
-              </div>
-            </div>
-          </div>
-          <div class="modal-footer">
-            <button class="btn btn-secondary" data-bs-dismiss="modal">닫기</button>
-            <button class="btn btn-primary" @click="save">저장</button>
-          </div>
-        </div>
-      </div>
-    </div>
+    <EmployeeFormModal :form="form" @save="save" />
   </div>
 </template>
 

--- a/frontend/src/modules/eval-items/components/EvalItemForm.vue
+++ b/frontend/src/modules/eval-items/components/EvalItemForm.vue
@@ -1,0 +1,51 @@
+<script setup>
+import { toRefs, computed } from 'vue'
+
+const props = defineProps({
+  form: { type: Object, required: true },
+  categories: { type: Array, default: () => [] },
+})
+const emit = defineEmits(['save', 'add-category'])
+const { form, categories } = toRefs(props)
+const isEdit = computed(() => !!form.value.id)
+</script>
+
+<template>
+  <div class="row g-2 align-items-end">
+    <div class="col-md-5">
+      <label class="form-label">평가 항목명</label>
+      <input v-model="form.name" class="form-control" placeholder="예: 신제품 아이디어 기여도" />
+    </div>
+    <div class="col-md-4">
+      <label class="form-label">카테고리</label>
+      <div class="input-group">
+        <select v-model="form.categoryId" class="form-select">
+          <option value="">선택</option>
+          <option v-for="c in categories" :key="c.id" :value="c.id">{{ c.name }}</option>
+        </select>
+        <button class="btn btn-outline-secondary" data-bs-toggle="modal" data-bs-target="#addCat">+ 새 카테고리</button>
+      </div>
+    </div>
+    <div class="col-md-3">
+      <label class="form-label">배점(점수)</label>
+      <input v-model.number="form.maxScore" type="number" class="form-control" placeholder="예: 10, 20" />
+    </div>
+    <div class="col-md-3">
+      <label class="form-label">사용 여부</label>
+      <select v-model="form.enabled" class="form-select">
+        <option :value="true">사용</option>
+        <option :value="false">미사용</option>
+      </select>
+    </div>
+    <div class="col-12">
+      <label class="form-label">비고</label>
+      <input v-model="form.description" class="form-control" placeholder="평가 기준 또는 설명 입력" />
+    </div>
+    <div class="col-12 d-flex gap-2 mt-2 justify-content-end">
+      <button class="btn btn-secondary" data-bs-dismiss="modal">닫기</button>
+      <button class="btn btn-primary" @click="$emit('save')">{{ isEdit ? '수정' : '저장' }}</button>
+    </div>
+  </div>
+</template>
+
+

--- a/frontend/src/modules/eval-items/pages/EvalItemsPage.vue
+++ b/frontend/src/modules/eval-items/pages/EvalItemsPage.vue
@@ -1,6 +1,8 @@
 <script setup>
 import { ref, onMounted, computed } from 'vue'
 import { getEvalCategories, getEvalItems, createEvalItem, updateEvalItem, createCategory } from '../services/eval-items.service'
+import EvalItemForm from '../components/EvalItemForm.vue'
+import { toast } from '../../../services/toast'
 
 // 검색 영역
 const keyword = ref('')
@@ -43,7 +45,7 @@ const saveItem = async () => {
   }
   if (form.value.id) await updateEvalItem(form.value.id, payload)
   else await createEvalItem(payload)
-  await load(); showForm.value = false; alert('저장 완료')
+  await load(); showForm.value = false; toast('저장 완료', 'success')
 }
 
 const addCategory = async () => {
@@ -94,41 +96,7 @@ onMounted(load)
 
     <div class="mt-4" v-if="showForm">
       <h5 class="mb-3">평가항목 등록</h5>
-      <div class="row g-2 align-items-end">
-        <div class="col-md-5">
-          <label class="form-label">평가 항목명</label>
-          <input v-model="form.name" class="form-control" placeholder="예: 신제품 아이디어 기여도" />
-        </div>
-        <div class="col-md-4">
-          <label class="form-label">카테고리</label>
-          <div class="input-group">
-            <select v-model="form.categoryId" class="form-select">
-              <option value="">선택</option>
-              <option v-for="c in categories" :key="c.id" :value="c.id">{{ c.name }}</option>
-            </select>
-            <button class="btn btn-outline-secondary" data-bs-toggle="modal" data-bs-target="#addCat">+ 새 카테고리</button>
-          </div>
-        </div>
-        <div class="col-md-3">
-          <label class="form-label">배점(점수)</label>
-          <input v-model.number="form.maxScore" type="number" class="form-control" placeholder="예: 10, 20" />
-        </div>
-        <div class="col-md-3">
-          <label class="form-label">사용 여부</label>
-          <select v-model="form.enabled" class="form-select">
-            <option :value="true">사용</option>
-            <option :value="false">미사용</option>
-          </select>
-        </div>
-        <div class="col-12">
-          <label class="form-label">비고</label>
-          <input v-model="form.description" class="form-control" placeholder="평가 기준 또는 설명 입력" />
-        </div>
-        <div class="col-12 d-flex gap-2 mt-2 justify-content-end">
-          <button class="btn btn-secondary" @click="showForm=false">목록</button>
-          <button class="btn btn-primary" @click="saveItem">저장</button>
-        </div>
-      </div>
+      <EvalItemForm :form="form" :categories="categories" @save="saveItem" />
     </div>
 
     <!-- 새 카테고리 모달 -->

--- a/frontend/src/modules/evaluation/components/EvaluationRows.vue
+++ b/frontend/src/modules/evaluation/components/EvaluationRows.vue
@@ -1,0 +1,26 @@
+<script setup>
+import { toRefs } from 'vue'
+
+const props = defineProps({
+  rows: { type: Array, required: true },
+  items: { type: Array, default: () => [] },
+})
+const emit = defineEmits(['add', 'remove'])
+const { rows, items } = toRefs(props)
+</script>
+
+<template>
+  <div>
+    <div v-for="(r, idx) in rows" :key="r.id" class="d-flex gap-2 mb-2">
+      <select v-model="r.itemId" class="form-select">
+        <option :value="null">항목 선택</option>
+        <option v-for="it in items" :key="it.id" :value="it.id">{{ it.name }}</option>
+      </select>
+      <input v-model.number="r.score" type="number" class="form-control" placeholder="점수" style="max-width:120px"/>
+      <button class="btn btn-outline-danger" @click="$emit('remove', idx)">삭제</button>
+    </div>
+    <button class="btn btn-outline-primary btn-sm" @click="$emit('add')">+ 항목 추가</button>
+  </div>
+</template>
+
+

--- a/frontend/src/modules/evaluation/pages/EvaluationPage.vue
+++ b/frontend/src/modules/evaluation/pages/EvaluationPage.vue
@@ -2,6 +2,8 @@
 import { ref, onMounted } from 'vue'
 import { searchEmployees } from '../../employees/services/employees.service'
 import { getEvalItems, saveEvaluations, saveMemo, saveRaise, getEvaluations, getRaise } from '../services/evaluation.service'
+import EvaluationRows from '../components/EvaluationRows.vue'
+import { toast } from '../../../services/toast'
 
 const employees = ref([])
 const items = ref([])
@@ -61,7 +63,7 @@ const saveRow = async (emp) => {
     const saved = res.data.data || []
     rowsByEmp.value[emp.id] = saved.map(s => ({ id: Date.now()+Math.random(), itemId: s.itemId, score: s.score }))
   } catch {}
-  alert('저장 완료')
+  toast('저장 완료', 'success')
 }
 
 const load = async () => {
@@ -114,15 +116,7 @@ onMounted(load)
           <td>{{ e.joinYear }}</td>
           <td>₩{{ Number(e.baseSalary).toLocaleString() }}</td>
           <td>
-            <div v-for="(r, idx) in rowsByEmp[e.id]" :key="r.id" class="d-flex gap-2 mb-2">
-              <select v-model="r.itemId" class="form-select">
-                <option :value="null">항목 선택</option>
-                <option v-for="it in items" :key="it.id" :value="it.id">{{ it.name }}</option>
-              </select>
-              <input v-model.number="r.score" type="number" class="form-control" placeholder="점수" style="max-width:120px"/>
-              <button class="btn btn-outline-danger" @click="removeRow(e.id, idx)">삭제</button>
-            </div>
-            <button class="btn btn-outline-primary btn-sm" @click="addRow(e.id)">+ 항목 추가</button>
+            <EvaluationRows :rows="rowsByEmp[e.id]" :items="items" @add="addRow(e.id)" @remove="(idx) => removeRow(e.id, idx)" />
           </td>
           <td class="fw-bold">{{ totalScore(e.id) }}</td>
           <td>

--- a/frontend/src/modules/report/components/Charts.vue
+++ b/frontend/src/modules/report/components/Charts.vue
@@ -1,0 +1,57 @@
+<script setup>
+import { ref, onBeforeUnmount, watch } from 'vue'
+import Chart from 'chart.js/auto'
+
+const props = defineProps({
+  names: { type: Array, default: () => [] },
+  base: { type: Array, default: () => [] },
+  raised: { type: Array, default: () => [] },
+  scores: { type: Array, default: () => [] },
+})
+
+const currency = n => `₩${Number(n || 0).toLocaleString()}`
+
+const barRef = ref(null)
+const lineRef = ref(null)
+let barChart, lineChart
+
+const draw = () => {
+  if (barChart) barChart.destroy()
+  if (lineChart) lineChart.destroy()
+  barChart = new Chart(barRef.value.getContext('2d'), {
+    type: 'bar',
+    data: { labels: props.names, datasets: [
+      { label: '이전 연봉', data: props.base, backgroundColor: '#74b9ff' },
+      { label: '상승 후 연봉', data: props.raised, backgroundColor: '#a29bfe' },
+    ]},
+    options: {
+      responsive: true, maintainAspectRatio: false,
+      plugins: { legend: { position: 'top' }, tooltip: { callbacks: { label: c => `${c.dataset.label}: ${currency(c.parsed.y)}` } } },
+      scales: { y: { beginAtZero: true, ticks: { callback: v => currency(v) } } },
+    },
+  })
+  lineChart = new Chart(lineRef.value.getContext('2d'), {
+    type: 'line',
+    data: { labels: props.names, datasets: [
+      { label: '직원별 점수 추이', data: props.scores, fill: true, tension: 0.2, cubicInterpolationMode: 'monotone', borderColor: '#ff7675', backgroundColor: 'rgba(255,118,117,0.2)', pointBackgroundColor: '#ff7675' },
+    ]},
+    options: { responsive: true, maintainAspectRatio: false, scales: { y: { suggestedMin: 0, suggestedMax: 100 } } },
+  })
+}
+
+watch(() => [props.names, props.base, props.raised, props.scores], draw, { deep: true })
+onBeforeUnmount(() => { if (barChart) barChart.destroy(); if (lineChart) lineChart.destroy() })
+</script>
+
+<template>
+  <div class="row g-3">
+    <div class="col-md-6">
+      <div style="height: 320px" class="card p-3"><canvas ref="barRef"></canvas></div>
+    </div>
+    <div class="col-md-6">
+      <div style="height: 320px" class="card p-3"><canvas ref="lineRef"></canvas></div>
+    </div>
+  </div>
+</template>
+
+

--- a/frontend/src/services/toast.js
+++ b/frontend/src/services/toast.js
@@ -1,0 +1,16 @@
+export function toast(message, variant = 'primary') {
+  const el = document.createElement('div')
+  el.className = `position-fixed top-0 end-0 p-3`
+  el.style.zIndex = 1080
+  el.innerHTML = `
+    <div class="toast align-items-center text-bg-${variant} border-0 show" role="alert" aria-live="assertive" aria-atomic="true">
+      <div class="d-flex">
+        <div class="toast-body">${message}</div>
+        <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+      </div>
+    </div>`
+  document.body.appendChild(el)
+  setTimeout(() => el.remove(), 2500)
+}
+
+


### PR DESCRIPTION
프론트 구조를 모듈 계층형으로 보강하고, 화면 단위에서 컴포넌트를 분리했습니다.\n\n- employees: 모달 컴포넌트 분리\n- eval-items: 폼 컴포넌트 분리 + 토스트 공통화\n- evaluation: 행 컴포넌트 분리 + 토스트 공통화\n- report: 차트 컴포넌트 분리\n- Vite 빌드 성공